### PR TITLE
Listview and Gridview switcher

### DIFF
--- a/OneDrive-Cloud-Player/Views/MainPage.xaml
+++ b/OneDrive-Cloud-Player/Views/MainPage.xaml
@@ -262,7 +262,8 @@
             </Grid>
             <UserControls:ExplorerListViewControl 
                 Grid.Row="3"
-                ExplorerItemsList="{Binding ExplorerItemsList}">
+                CurrentExplorerItems="{Binding ExplorerItemsList}"
+				CurrentSelectedExplorerItem="{Binding SelectedExplorerItem, Mode=TwoWay}">
                 <Interactivity:Interaction.Behaviors>
                     <Core:EventTriggerBehavior EventName="UserControlClicked">
                         <Core:InvokeCommandAction Command="{Binding GetChildrenFomItemCommand}"/>

--- a/OneDrive-Cloud-Player/Views/MainPage.xaml
+++ b/OneDrive-Cloud-Player/Views/MainPage.xaml
@@ -263,7 +263,8 @@
             <UserControls:ExplorerListViewControl 
                 Grid.Row="3"
                 CurrentExplorerItems="{Binding ExplorerItemsList}"
-				CurrentSelectedExplorerItem="{Binding SelectedExplorerItem, Mode=TwoWay}">
+				CurrentSelectedExplorerItem="{Binding SelectedExplorerItem, Mode=TwoWay}"
+				ControlViewType="Grid">
                 <Interactivity:Interaction.Behaviors>
                     <Core:EventTriggerBehavior EventName="UserControlClicked">
                         <Core:InvokeCommandAction Command="{Binding GetChildrenFomItemCommand}"/>

--- a/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml
+++ b/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml
@@ -18,8 +18,8 @@
 
     <Grid>
         <ListView Grid.Row="3" x:Name="ExplorerListBox" 
-                     ItemsSource="{Binding ExplorerItemsList}"
-                     SelectedItem="{Binding SelectedExplorerItem, Mode=TwoWay}" 
+                     ItemsSource="{Binding CurrentExplorerItems}"
+                     SelectedItem="{Binding CurrentSelectedExplorerItem, Mode=TwoWay}" 
                      Background="Transparent" 
                      HorizontalAlignment="Stretch"
                      RequestedTheme="Dark"

--- a/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml
+++ b/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml
@@ -17,9 +17,10 @@
     </UserControl.Resources>
 
     <Grid>
-        <ListView Grid.Row="3" x:Name="ExplorerListBox" 
-                     ItemsSource="{Binding CurrentExplorerItems}"
-                     SelectedItem="{Binding CurrentSelectedExplorerItem, Mode=TwoWay}" 
+		<!--ItemsSource="{Binding CurrentExplorerItems}"
+                     SelectedItem="{Binding CurrentSelectedExplorerItem, Mode=TwoWay}"-->
+		<ListView Grid.Row="3" x:Name="ExplorerListBox" 
+                     Visibility="Collapsed"
                      Background="Transparent" 
                      HorizontalAlignment="Stretch"
                      RequestedTheme="Dark"
@@ -76,5 +77,63 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
+
+		<GridView Grid.Row="3" x:Name="ExplorerGridBox" 
+                     Visibility="Collapsed"
+                     Background="Transparent" 
+                     HorizontalAlignment="Stretch"
+                     RequestedTheme="Dark"
+                     DoubleTapped="ExplorerListBox_MouseDown">
+			<GridView.ItemContainerStyle>
+				<Style TargetType="ListViewItem">
+					<Setter Property="Background" Value="Transparent"/>
+					<Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+					<Setter Property="FontSize" Value="16"/>
+					<Setter Property="FontFamily" Value="Arial"/>
+					<Setter Property="Foreground" Value="white"/>
+					<Setter Property="Padding" Value="0"/>
+					<!--<Setter Property="HorizontalAlignment" Value="Stretch"/>-->
+					<!--<Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                                    <Border Background="{TemplateBinding Background}">
+                                        <ContentPresenter HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>-->
+					<!--<Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="#414E58"/>
+                            </Trigger>
+                        </Style.Triggers>-->
+				</Style>
+
+			</GridView.ItemContainerStyle>
+
+			<!--Template for the individual explorer items-->
+			<GridView.ItemTemplate>
+				<DataTemplate>
+
+					<StackPanel x:Name="FolderStackPanel" Height="51">
+						<Border BorderThickness="0, 0, 0, 2" BorderBrush="#1AFFFFFF">
+							<Grid>
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="50"/>
+									<ColumnDefinition Width="*"/>
+									<ColumnDefinition Width="100"/>
+									<ColumnDefinition Width="85"/>
+								</Grid.ColumnDefinitions>
+
+								<Image Grid.Column="0" Source="{Binding Path=IsFolder, Converter={StaticResource converter}, ConverterParameter='ContentTypeExplorerItem'}" VerticalAlignment="Center" HorizontalAlignment="Center" Width="20"/>
+								<TextBlock Grid.Column="1" x:Name="ItemName" Text="{Binding Name}" Padding="40, 15, 15, 15" />
+								<TextBlock Grid.Column="2" Text="{Binding Converter={StaticResource converter}, ConverterParameter='ContentChildCountExplorer'}" VerticalAlignment="Center"/>
+								<TextBlock Grid.Column="3" Text="{Binding Size, Converter={StaticResource converter}, ConverterParameter='ContentItemSizeExplorer'}" VerticalAlignment="Center"/>
+							</Grid>
+						</Border>
+					</StackPanel>
+				</DataTemplate>
+			</GridView.ItemTemplate>
+		</GridView>
     </Grid>
 </UserControl>

--- a/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml.cs
+++ b/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml.cs
@@ -1,13 +1,16 @@
 ﻿
 using CommonServiceLocator;
+using GalaSoft.MvvmLight;
 using Microsoft.Graph;
 using OneDrive_Cloud_Player.Models.GraphData;
 using OneDrive_Cloud_Player.ViewModels;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
@@ -23,30 +26,70 @@ using Windows.UI.Xaml.Navigation;
 
 namespace OneDrive_Cloud_Player.Views.UserControls
 {
-    public sealed partial class ExplorerListViewControl : UserControl
+    public sealed partial class ExplorerListViewControl : UserControl, INotifyPropertyChanged
     {
-
-        public List<CachedDriveItem> ExplorerItemsList
+        /// <summary>
+        /// Codebehind property that can be set from the xaml code
+        /// </summary>
+        public List<CachedDriveItem> CurrentExplorerItems
         {
-            get { return (List<CachedDriveItem>)GetValue(ExplorerItemsListProperty); }
-            set { SetValue(ExplorerItemsListProperty, value); }
+            get 
+            { 
+                return (List<CachedDriveItem>)GetValue(ExplorerItemsDependency); 
+            }
+            set 
+            {
+                SetValueDependency(ExplorerItemsDependency, value);
+            }
         }
 
-        // Using a DependencyProperty as the backing store for ExplorerItemsList.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty ExplorerItemsListProperty =
-            DependencyProperty.Register("ExplorerItemsList", typeof(List<CachedDriveItem>), typeof(ExplorerListViewControl), new PropertyMetadata(0));
+        /// <summary>
+        /// Codebehind property that can be set from the xaml code
+        /// </summary>
+        public CachedDriveItem CurrentSelectedExplorerItem
+        {
+            get 
+            { 
+                return (CachedDriveItem)GetValue(SelectedExplorerItemDependency); 
+            }
+            set 
+            {
+                SetValueDependency(SelectedExplorerItemDependency, value);
+            }
+        }
+
+        // Using a DependencyProperty as the backing store for ExplorerItems.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ExplorerItemsDependency =
+            DependencyProperty.Register("CurrentExplorerItems", typeof(List<CachedDriveItem>), typeof(ExplorerListViewControl), null);
+
+        public static readonly DependencyProperty SelectedExplorerItemDependency =
+            DependencyProperty.Register("CurrentSelectedExplorerItem", typeof(CachedDriveItem), typeof(ExplorerListViewControl), null);
+ 
 
         public ExplorerListViewControl()
         {
             this.InitializeComponent();
+
+            //required for using this element as a bindable datacontext
+            (this.Content as FrameworkElement).DataContext = this;
         }
 
+        public event DoubleTappedEventHandler UserControlClicked;
+		public event PropertyChangedEventHandler PropertyChanged;
 
-        public event EventHandler UserControlClicked;
-
-        private void ExplorerListBox_MouseDown(object sender, DoubleTappedRoutedEventArgs e)
+		private void ExplorerListBox_MouseDown(object sender, DoubleTappedRoutedEventArgs e)
         {
-            UserControlClicked?.Invoke(this, EventArgs.Empty);
+            UserControlClicked?.Invoke(this, e);         
         }
+
+        /// <summary>
+        /// Sets the value of the depenency and updates it to the view
+        /// </summary>
+        /// <param name="propertyName"></param>
+		private void SetValueDependency(DependencyProperty property, object value, [CallerMemberName] String p = null)
+        {
+            SetValue(property, value);
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(p));
+		}
     }
 }

--- a/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml.cs
+++ b/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml.cs
@@ -28,6 +28,12 @@ namespace OneDrive_Cloud_Player.Views.UserControls
 {
     public sealed partial class ExplorerListViewControl : UserControl, INotifyPropertyChanged
     {
+        public enum ViewType
+		{
+            Grid = 1000, 
+            List = 2000
+		}
+
         /// <summary>
         /// Codebehind property that can be set from the xaml code
         /// </summary>
@@ -58,13 +64,41 @@ namespace OneDrive_Cloud_Player.Views.UserControls
             }
         }
 
-        // Using a DependencyProperty as the backing store for ExplorerItems.  This enables animation, styling, binding, etc...
+        public ViewType ControlViewType
+		{
+            get
+            {
+                return (ViewType)GetValue(ControlViewTypeDependency);
+            }
+            set
+            {
+                SetValueDependency(ControlViewTypeDependency, value);
+                ViewTypeChanged(); //trigger an update with custom code
+            }
+        }
+
+
+        /// <summary>
+        /// Dependency Property for the ExplorerItems, this allows binding to it from a parent class
+        /// </summary>
         public static readonly DependencyProperty ExplorerItemsDependency =
             DependencyProperty.Register("CurrentExplorerItems", typeof(List<CachedDriveItem>), typeof(ExplorerListViewControl), null);
 
+        /// <summary>
+        /// Dependency Property for the SelectedExplorerItem, this allows binding to it from a parent class.
+        /// </summary>
         public static readonly DependencyProperty SelectedExplorerItemDependency =
             DependencyProperty.Register("CurrentSelectedExplorerItem", typeof(CachedDriveItem), typeof(ExplorerListViewControl), null);
- 
+
+        /// <summary>
+        /// Dependency Property for the SelectedExplorerItem, this allows binding to it from a parent class.
+        /// </summary>
+        public static readonly DependencyProperty ControlViewTypeDependency =
+            DependencyProperty.Register("ControlViewType", typeof(CachedDriveItem), typeof(ExplorerListViewControl), null);
+
+
+        public event DoubleTappedEventHandler UserControlClicked;
+        public event PropertyChangedEventHandler PropertyChanged;
 
         public ExplorerListViewControl()
         {
@@ -74,9 +108,11 @@ namespace OneDrive_Cloud_Player.Views.UserControls
             (this.Content as FrameworkElement).DataContext = this;
         }
 
-        public event DoubleTappedEventHandler UserControlClicked;
-		public event PropertyChangedEventHandler PropertyChanged;
-
+        /// <summary>
+        /// The event used for double clicking a list item.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
 		private void ExplorerListBox_MouseDown(object sender, DoubleTappedRoutedEventArgs e)
         {
             UserControlClicked?.Invoke(this, e);         
@@ -91,5 +127,77 @@ namespace OneDrive_Cloud_Player.Views.UserControls
             SetValue(property, value);
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(p));
 		}
-    }
+
+        /// <summary>
+        /// Handles the viewtype changed event, this function also fires the on the first load, as mvvm is slow and needs time to load its dependency values :)
+        /// </summary>
+        private void ViewTypeChanged()
+		{
+            Console.WriteLine("MainPage display type: " + ControlViewType);
+
+			switch (ControlViewType)
+			{
+				case ViewType.Grid:
+                    //enable the gridview
+                    EnableGridView();
+
+                    //disable the listview (even if this was never enabled)
+                    DisableListView();
+                    break;
+				case ViewType.List:
+                    //enable the listview
+                    EnableListView();
+
+                    //disable the gridview (even if this was never enabled)
+                    DisableGridView();
+                    break;
+			}			
+		}
+
+        private void EnableListView()
+        {
+            ExplorerListBox.Visibility = Visibility.Visible;
+
+            //create a selectedItem binding for the listbox
+            Binding selectedItemBinding = new Binding();
+            selectedItemBinding.Path = new PropertyPath("CurrentSelectedExplorerItem");
+            selectedItemBinding.Mode = BindingMode.TwoWay;
+            ExplorerListBox.SetBinding(Selector.SelectedItemProperty, selectedItemBinding);
+
+            //create a listsource binding for the listbox
+            Binding listSource = new Binding();
+            listSource.Path = new PropertyPath("CurrentExplorerItems");
+            ExplorerListBox.SetBinding(ItemsControl.ItemsSourceProperty, listSource);
+        }
+
+        private void DisableListView()
+		{
+            ExplorerListBox.Visibility = Visibility.Collapsed;
+            ExplorerListBox.ClearValue(SelectedExplorerItemDependency); //reset possible bindings
+            ExplorerListBox.ClearValue(ExplorerItemsDependency); //reset possible bindings
+        }
+
+        private void EnableGridView()
+		{
+            ExplorerGridBox.Visibility = Visibility.Visible;
+
+            //create a selectedItem binding for the listbox
+            Binding selectedItemBinding = new Binding();
+            selectedItemBinding.Path = new PropertyPath("CurrentSelectedExplorerItem");
+            selectedItemBinding.Mode = BindingMode.TwoWay;
+            ExplorerGridBox.SetBinding(Selector.SelectedItemProperty, selectedItemBinding);
+
+            //create a listsource binding for the listbox
+            Binding listSource = new Binding();
+            listSource.Path = new PropertyPath("CurrentExplorerItems");
+            ExplorerGridBox.SetBinding(ItemsControl.ItemsSourceProperty, listSource);
+        }
+
+        private void DisableGridView()
+		{
+            ExplorerGridBox.Visibility = Visibility.Collapsed;
+            ExplorerGridBox.ClearValue(SelectedExplorerItemDependency); //reset possible bindings
+            ExplorerGridBox.ClearValue(ExplorerItemsDependency); //reset possible bindings
+        }
+	}
 }

--- a/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml.cs
+++ b/OneDrive-Cloud-Player/Views/UserControls/ExplorerListViewControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿
+
 using CommonServiceLocator;
 using GalaSoft.MvvmLight;
 using Microsoft.Graph;
@@ -29,21 +29,21 @@ namespace OneDrive_Cloud_Player.Views.UserControls
     public sealed partial class ExplorerListViewControl : UserControl, INotifyPropertyChanged
     {
         public enum ViewType
-		{
-            Grid = 1000, 
+        {
+            Grid = 1000,
             List = 2000
-		}
+        }
 
         /// <summary>
         /// Codebehind property that can be set from the xaml code
         /// </summary>
         public List<CachedDriveItem> CurrentExplorerItems
         {
-            get 
-            { 
-                return (List<CachedDriveItem>)GetValue(ExplorerItemsDependency); 
+            get
+            {
+                return (List<CachedDriveItem>)GetValue(ExplorerItemsDependency);
             }
-            set 
+            set
             {
                 SetValueDependency(ExplorerItemsDependency, value);
             }
@@ -54,18 +54,18 @@ namespace OneDrive_Cloud_Player.Views.UserControls
         /// </summary>
         public CachedDriveItem CurrentSelectedExplorerItem
         {
-            get 
-            { 
-                return (CachedDriveItem)GetValue(SelectedExplorerItemDependency); 
+            get
+            {
+                return (CachedDriveItem)GetValue(SelectedExplorerItemDependency);
             }
-            set 
+            set
             {
                 SetValueDependency(SelectedExplorerItemDependency, value);
             }
         }
 
         public ViewType ControlViewType
-		{
+        {
             get
             {
                 return (ViewType)GetValue(ControlViewTypeDependency);
@@ -115,7 +115,7 @@ namespace OneDrive_Cloud_Player.Views.UserControls
         /// <param name="e"></param>
 		private void ExplorerListBox_MouseDown(object sender, DoubleTappedRoutedEventArgs e)
         {
-            UserControlClicked?.Invoke(this, e);         
+            UserControlClicked?.Invoke(this, e);
         }
 
         /// <summary>
@@ -125,34 +125,34 @@ namespace OneDrive_Cloud_Player.Views.UserControls
 		private void SetValueDependency(DependencyProperty property, object value, [CallerMemberName] String p = null)
         {
             SetValue(property, value);
-			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(p));
-		}
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(p));
+        }
 
         /// <summary>
         /// Handles the viewtype changed event, this function also fires the on the first load, as mvvm is slow and needs time to load its dependency values :)
         /// </summary>
         private void ViewTypeChanged()
-		{
+        {
             Console.WriteLine("MainPage display type: " + ControlViewType);
 
-			switch (ControlViewType)
-			{
-				case ViewType.Grid:
+            switch (ControlViewType)
+            {
+                case ViewType.Grid:
                     //enable the gridview
                     EnableGridView();
 
                     //disable the listview (even if this was never enabled)
                     DisableListView();
                     break;
-				case ViewType.List:
+                case ViewType.List:
                     //enable the listview
                     EnableListView();
 
                     //disable the gridview (even if this was never enabled)
                     DisableGridView();
                     break;
-			}			
-		}
+            }
+        }
 
         private void EnableListView()
         {
@@ -171,14 +171,14 @@ namespace OneDrive_Cloud_Player.Views.UserControls
         }
 
         private void DisableListView()
-		{
+        {
             ExplorerListBox.Visibility = Visibility.Collapsed;
             ExplorerListBox.ClearValue(SelectedExplorerItemDependency); //reset possible bindings
             ExplorerListBox.ClearValue(ExplorerItemsDependency); //reset possible bindings
         }
 
         private void EnableGridView()
-		{
+        {
             ExplorerGridBox.Visibility = Visibility.Visible;
 
             //create a selectedItem binding for the listbox
@@ -194,10 +194,10 @@ namespace OneDrive_Cloud_Player.Views.UserControls
         }
 
         private void DisableGridView()
-		{
+        {
             ExplorerGridBox.Visibility = Visibility.Collapsed;
             ExplorerGridBox.ClearValue(SelectedExplorerItemDependency); //reset possible bindings
             ExplorerGridBox.ClearValue(ExplorerItemsDependency); //reset possible bindings
         }
-	}
+    }
 }


### PR DESCRIPTION
Added a bindable option on the Usercontrol to allow for switching between a grid and a list.

Inside the control "ExplorerListViewControl" there are 2 views (grid & list) these are toggled by the property ControlViewType, an example of how to use this: 

```xaml
<UserControls:ExplorerListViewControl 
    Grid.Row="3"
    CurrentExplorerItems="{Binding ExplorerItemsList}"
	CurrentSelectedExplorerItem="{Binding SelectedExplorerItem, Mode=TwoWay}"
	ControlViewType="Grid">
    <Interactivity:Interaction.Behaviors>
        <Core:EventTriggerBehavior EventName="UserControlClicked">
            <Core:InvokeCommandAction Command="{Binding GetChildrenFomItemCommand}"/>
        </Core:EventTriggerBehavior>
    </Interactivity:Interaction.Behaviors>
</UserControls:ExplorerListViewControl>
```
I also added the gridview, this is not styled as i copied its properties from the listview, its not nice, but it works and displays.