### PR TITLE
removed unused property

### DIFF
--- a/OneDrive-Cloud-Player/Services/Helpers/CacheHelper.cs
+++ b/OneDrive-Cloud-Player/Services/Helpers/CacheHelper.cs
@@ -208,14 +208,12 @@ namespace OneDrive_Cloud_Player.Services
                     driveToAdd.DriveName = "Your Drive";
                     driveToAdd.DriveId = graphDrive.ParentReference.DriveId;
                     driveToAdd.IsSharedFolder = false;
-                    driveToAdd.OwnerName = CurrentUsername;
                 }
                 else
                 {
                     driveToAdd.DriveName = graphDrive.Name;
                     driveToAdd.DriveId = graphDrive.RemoteItem.ParentReference.DriveId;
                     driveToAdd.IsSharedFolder = true;
-                    driveToAdd.OwnerName = graphDrive.RemoteItem.Shared.SharedBy.User.DisplayName;
                 }
                 newlyCachedDrives.Add(driveToAdd);
             }


### PR DESCRIPTION
This was the cause of some weird behaviour where MS Graph would leave out some fields like the name of a shared folder, even though that owner exists.  Since we didn't use the ownername anyway, I have removed it.
Still need to look at the JSON structure overall. @GrandDynamo