### PR TITLE
Foreward and Backward arrow controls implemented

### DIFF
--- a/OneDrive-Cloud-Player/ViewModels/VideoPlayerPageViewModel.cs
+++ b/OneDrive-Cloud-Player/ViewModels/VideoPlayerPageViewModel.cs
@@ -309,17 +309,25 @@ namespace OneDrive_Cloud_Player.ViewModels
         /// </summary>
         private void Seeked()
         {
-            // Check wether or not the media should be reloaded.
-            if (InvalidOneDriveSession)
-            {
-                //TODO: fix seekbar niet going instantly to the point where the user clicked. This gives the illusion that the seekbar is broken.
-                ReloadCurrentMedia();
-            }
-            else
-            {
-                SetVideoTime(TimeLineValue);
-            }
+            SetVideoTime(TimeLineValue);
         }
+
+        /// <summary>
+        /// Seek backwards in the media.
+        /// </summary>
+        public void SeekBackward()
+        {
+            SetVideoTime(MediaPlayer.Time -= 10000);
+        }
+
+        /// <summary>
+        /// Seek foreward in the media.
+        /// </summary>
+        public void SeekForeward()
+        {
+            SetVideoTime(MediaPlayer.Time += 10000);
+        }
+
 
         /// <summary>
         /// Sets the time of the media with the given time.
@@ -329,7 +337,9 @@ namespace OneDrive_Cloud_Player.ViewModels
         {
             if (InvalidOneDriveSession)
             {
-                Debug.WriteLine("OneDrive link expired.");
+                Debug.WriteLine(" + OneDrive link expired.");
+                Debug.WriteLine("   + Reloading media.");
+                ReloadCurrentMedia();
             }
             MediaPlayer.Time = time;
         }
@@ -382,6 +392,12 @@ namespace OneDrive_Cloud_Player.ViewModels
             {
                 case VirtualKey.Space:
                     ChangePlayingState();
+                    break;
+                case VirtualKey.Left:
+                    SeekBackward();
+                    break;
+                case VirtualKey.Right:
+                    SeekForeward();
                     break;
             }
         }

--- a/OneDrive-Cloud-Player/ViewModels/VideoPlayerPageViewModel.cs
+++ b/OneDrive-Cloud-Player/ViewModels/VideoPlayerPageViewModel.cs
@@ -313,21 +313,22 @@ namespace OneDrive_Cloud_Player.ViewModels
         }
 
         /// <summary>
-        /// Seek backwards in the media.
+        /// Seek backwards in the media by given miliseconds.
         /// </summary>
-        public void SeekBackward()
+        /// <param name="ms"></param>
+        public void SeekBackward(long ms)
         {
-            SetVideoTime(MediaPlayer.Time -= 10000);
+            SetVideoTime(MediaPlayer.Time - ms);
         }
 
         /// <summary>
-        /// Seek foreward in the media.
+        /// Seek foreward in the media by given miliseconds.
         /// </summary>
-        public void SeekForeward()
+        /// <param name="ms"></param>
+        public void SeekForeward(long ms)
         {
-            SetVideoTime(MediaPlayer.Time += 10000);
+            SetVideoTime(MediaPlayer.Time + ms);
         }
-
 
         /// <summary>
         /// Sets the time of the media with the given time.
@@ -394,10 +395,16 @@ namespace OneDrive_Cloud_Player.ViewModels
                     ChangePlayingState();
                     break;
                 case VirtualKey.Left:
-                    SeekBackward();
+                    SeekBackward(5000);
                     break;
                 case VirtualKey.Right:
-                    SeekForeward();
+                    SeekForeward(5000);
+                    break;
+                case VirtualKey.J:
+                    SeekBackward(10000);
+                    break;
+                case VirtualKey.L:
+                    SeekForeward(10000);
                     break;
             }
         }


### PR DESCRIPTION
- #3 Implemented the foreward and backward controls. You can now go back and go foreward in the video by using the left and right arrow keys. The amount of time it changes is 10 seconds.

- Moved stream expiration (InvalidOneDriveSession) check in the method that sets the time of the video as it would only be needed to be checked when the media time needs to be changed.