### PR TITLE
Refactored GraphHelper class

### DIFF
--- a/OneDrive-Cloud-Player/Services/Helpers/CacheHelper.cs
+++ b/OneDrive-Cloud-Player/Services/Helpers/CacheHelper.cs
@@ -25,7 +25,7 @@ namespace OneDrive_Cloud_Player.Services
         public CacheHelper()
         {
             Cache = new List<OneDriveCache>();
-            Graph = new GraphHelper();
+            Graph = GraphHelper.Instance();
         }
 
         /// <summary>

--- a/OneDrive-Cloud-Player/Services/Helpers/GraphHelper.cs
+++ b/OneDrive-Cloud-Player/Services/Helpers/GraphHelper.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.Graph;
-using OneDrive_Cloud_Player.Services.Helpers;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace OneDrive_Cloud_Player.Services.Helpers
@@ -23,13 +18,13 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         public GraphHelper()
         {
             Auth = new GraphAuthHelper();
-            InitializeGraphHelperAsync();
+            InitializeGraphHelperAsync().Wait();
         }
 
         /// <summary>
         /// Create the Graph client and acquire an access token used to call the Graph API.
         /// </summary>
-        private async void InitializeGraphHelperAsync()
+        private async Task InitializeGraphHelperAsync()
         {
             GraphClient = new GraphServiceClient(await GetNewAuthenticationHeaderAsync());
         }
@@ -85,7 +80,7 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         }
 
         /// <summary>
-        /// Get the children that are inside a drive item. Rreturns null upon Graph ServiceException
+        /// Get the children that are inside a drive item. Returns null upon Graph ServiceException
         /// </summary>
         /// <param name="ItemId"></param>
         /// <param name="DriveId"></param>

--- a/OneDrive-Cloud-Player/Services/Helpers/GraphHelper.cs
+++ b/OneDrive-Cloud-Player/Services/Helpers/GraphHelper.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace OneDrive_Cloud_Player.Services.Helpers
 {
     /// <summary>
-    /// Used to create calls and retrieve information from the graph api.
+    /// Used to create calls and retrieve information from the Graph API.
     /// Try to save this data and use this class as little as possible for speed purposes.
     /// </summary>
     class GraphHelper
@@ -23,21 +23,39 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         public GraphHelper()
         {
             Auth = new GraphAuthHelper();
+            InitializeGraphHelperAsync();
         }
 
         /// <summary>
-        ///    Create the graph client with including acquiring an access token used to call the microsoft graph api.
+        /// Create the Graph client and acquire an access token used to call the Graph API.
         /// </summary>
-        private async Task CreateGraphClientAsync()
+        private async void InitializeGraphHelperAsync()
         {
-            //Acquire accesstoken.
+            GraphClient = new GraphServiceClient(await GetNewAuthenticationHeaderAsync());
+        }
+
+        /// <summary>
+        /// Update the authentication header of the GraphServiceClient with a new access token.
+        /// </summary>
+        private async Task RefreshAccesTokenAsync()
+        {
+            GraphClient.AuthenticationProvider = await GetNewAuthenticationHeaderAsync();
+        }
+
+        /// <summary>
+        /// Retrieve a new access token and construct an AuthenticationHeaderValue based upon it.
+        /// </summary>
+        /// <returns></returns>
+        private async Task<IAuthenticationProvider> GetNewAuthenticationHeaderAsync()
+        {
+            // Acquire accesstoken.
             string AccessToken = await Auth.GetAccessToken();
 
-            GraphClient = new GraphServiceClient(new DelegateAuthenticationProvider((requestMessage) =>
+            return new DelegateAuthenticationProvider((requestMessage) =>
             {
                 requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
                 return Task.FromResult(0);
-            }));
+            });
         }
 
         /// <summary>
@@ -47,9 +65,9 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         /// <returns></returns>
         public async Task<Drive> GetDriveInformationAsync(string DriveId)
         {
-            //Create a new GraphServiceClient.
-            await CreateGraphClientAsync();
-            //Return the name of the drive of type string.
+            // Refresh the access token.
+            await RefreshAccesTokenAsync();
+            // Return the name of the drive of type string.
             return await GraphClient.Me.Drives[DriveId].Request().GetAsync();
 
         }
@@ -60,9 +78,9 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         /// <returns></returns>
         public async Task<User> GetOneDriveUserInformationAsync()
         {
-            //Create a new GraphServiceClient.
-            await CreateGraphClientAsync();
-            //Return the user information in type Microsoft.Graph.User.
+            // Refresh the access token.
+            await RefreshAccesTokenAsync();
+            // Return the user information in type Microsoft.Graph.User.
             return await GraphClient.Me.Request().GetAsync();
         }
 
@@ -74,9 +92,9 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         /// <returns></returns>
         public async Task<IDriveItemChildrenCollectionPage> GetChildrenOfItemAsync(string DriveId, string ItemId)
         {
-            //Create a new GraphServiceClient.
-            await CreateGraphClientAsync();
-            //Return the children of the item on the given drive.
+            // Refresh the access token.
+            await RefreshAccesTokenAsync();
+            // Return the children of the item on the given drive.
             try
             {
                 return await GraphClient.Me.Drives[DriveId].Items[ItemId].Children.Request().GetAsync();
@@ -85,7 +103,6 @@ namespace OneDrive_Cloud_Player.Services.Helpers
             {
                 return null;
             }
-
         }
 
         /// <summary>
@@ -94,8 +111,8 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         /// <returns></returns>
         public async Task<DriveItem> GetUserRootDrive()
         {
-            //Create a new GraphServiceClient.
-            await CreateGraphClientAsync();
+            // Refresh the access token.
+            await RefreshAccesTokenAsync();
 
             return await GraphClient.Me.Drive.Root.Request().GetAsync();
         }
@@ -106,9 +123,9 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         /// <returns></returns>
         public async Task<IDriveSharedWithMeCollectionPage> GetSharedDrivesAsync()
         {
-            //Create a new GraphServiceClient.
-            await CreateGraphClientAsync();
-            //Return shared items.
+            // Refresh the access token.
+            await RefreshAccesTokenAsync();
+            // Return shared items.
             return await GraphClient.Me.Drive.SharedWithMe().Request().GetAsync();
         }
 
@@ -118,9 +135,9 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         /// <returns></returns>
         public async Task<Stream> GetOneDriveOwnerPhotoAsync()
         {
-            //Create a new GraphServiceClient.
-            await CreateGraphClientAsync();
-            //Return photo of the owner in binary data.
+            // Refresh the access token.
+            await RefreshAccesTokenAsync();
+            // Return photo of the owner in binary data.
             return await GraphClient.Me.Photo.Content.Request().GetAsync();
         }
 
@@ -132,9 +149,9 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         /// <returns></returns>
         public async Task<DriveItem> GetItemInformationAsync(string DriveId, string ItemId)
         {
-            //Create a new GraphServiceClient.
-            await CreateGraphClientAsync();
-            //Return information about an item that resides in the given drive id.
+            // Refresh the access token.
+            await RefreshAccesTokenAsync();
+            // Return information about an item that resides in the given drive id.
             return await GraphClient.Me.Drives[DriveId].Items[ItemId].Request().GetAsync();
         }
     }

--- a/OneDrive-Cloud-Player/Services/Helpers/GraphHelper.cs
+++ b/OneDrive-Cloud-Player/Services/Helpers/GraphHelper.cs
@@ -19,6 +19,11 @@ namespace OneDrive_Cloud_Player.Services.Helpers
         private static GraphHelper _instance = null;
         private static readonly object _instanceLock = new object();
 
+        /// <summary>
+        /// Returns the GraphHelper instance. Creates a new instance if it doesn't exist already.
+        /// This method is thread-safe.
+        /// </summary>
+        /// <returns>GraphHelper instance</returns>
         public static GraphHelper Instance()
         {
             lock (_instanceLock)

--- a/OneDrive-Cloud-Player/Services/Helpers/GraphHelper.cs
+++ b/OneDrive-Cloud-Player/Services/Helpers/GraphHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Graph;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -15,7 +16,22 @@ namespace OneDrive_Cloud_Player.Services.Helpers
 
         private GraphAuthHelper Auth { get; set; }
 
-        public GraphHelper()
+        private static GraphHelper _instance = null;
+        private static readonly object _instanceLock = new object();
+
+        public static GraphHelper Instance()
+        {
+            lock (_instanceLock)
+            {
+                if (_instance is null)
+                {
+                    _instance = new GraphHelper();
+                }
+            }
+            return _instance;
+        }
+
+        private GraphHelper()
         {
             Auth = new GraphAuthHelper();
             InitializeGraphHelperAsync().Wait();

--- a/OneDrive-Cloud-Player/ViewModels/MainPageViewModel.cs
+++ b/OneDrive-Cloud-Player/ViewModels/MainPageViewModel.cs
@@ -141,7 +141,7 @@ namespace OneDrive_Cloud_Player.ViewModels
             _navigationService = navigationService;
 
             DriveList = null;
-            this.graph = new GraphHelper();
+            this.graph = GraphHelper.Instance();
             //DisplayMessageCommand = new RelayCommand(DisplayMessage, CanExecuteCommand);
             GetDrivesCommand = new RelayCommand(GetDrives, CanExecuteCommand);
             GetChildrenFomItemCommand = new RelayCommand(GetChildrenFomItem, CanExecuteCommand);

--- a/OneDrive-Cloud-Player/ViewModels/VideoPlayerPageViewModel.cs
+++ b/OneDrive-Cloud-Player/ViewModels/VideoPlayerPageViewModel.cs
@@ -135,7 +135,7 @@ namespace OneDrive_Cloud_Player.ViewModels
         public VideoPlayerPageViewModel(INavigationService navigationService)
         {
             _navigationService = navigationService;
-            graphHelper = new GraphHelper();
+            graphHelper = GraphHelper.Instance();
             InitializeLibVLCCommand = new RelayCommand<InitializedEventArgs>(InitializeLibVLC);
             StartedDraggingThumbCommand = new RelayCommand(StartedDraggingThumb, CanExecuteCommand);
             StoppedDraggingThumbCommand = new RelayCommand(StoppedDraggingThumb, CanExecuteCommand);


### PR DESCRIPTION
GraphHelper.cs:
- add: Method for initializing the GraphHelper class, retreiving an AuthenticationHeader with an updated access token and updating the GraphServiceClient AuthenticationProvider. Also made the documentation more consistent.
- chg: Upon every API call, the GraphServiceClient is not reïnstantiated. This is both a cleaner and faster way to handle access token refreshes, which was the original purpose of the constant recreation.

This tackles the problem of constant receration. However, I have also considered making this class a singleton, which should cover it's use throughout the entire code base. What do you think @GrandDynamo ?