### PR TITLE
Fixed media controls not hiding. This PR fixes issue #47

### DIFF
--- a/OneDrive-Cloud-Player/Views/VideoPlayerPage.xaml.cs
+++ b/OneDrive-Cloud-Player/Views/VideoPlayerPage.xaml.cs
@@ -64,7 +64,7 @@ namespace OneDrive_Cloud_Player.Views
         /// </summary>
         private void MediaControlGrid_PointerExited(object sender, PointerRoutedEventArgs e)
         {
-            isPointerOverMediaControl = true;
+            isPointerOverMediaControl = false;
         }
 
         /// <summary>


### PR DESCRIPTION
VideoPlayerPage.xaml.cs:
 - fix: A property was set to the wrong boolean when exiting the media controls. This has been changed to the correct boolean value.