### PR TITLE
Added Subtitle Track selector

### DIFF
--- a/OneDrive-Cloud-Player/App.xaml.cs
+++ b/OneDrive-Cloud-Player/App.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.AppCenter.Crashes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Identity.Client;
 using OneDrive_Cloud_Player.Models.GraphData;
+using OneDrive_Cloud_Player.Models.Interfaces;
 using OneDrive_Cloud_Player.Services;
 using OneDrive_Cloud_Player.Views;
 using System;
@@ -83,6 +84,7 @@ namespace OneDrive_Cloud_Player
             var serviceCollection = new ServiceCollection();
 
             // Add services for dependency injection here.
+            serviceCollection.AddTransient<IMediaTrackService, MediaTrackService>();
 
             return serviceCollection.BuildServiceProvider();
         }

--- a/OneDrive-Cloud-Player/Models/Interfaces/IMediaTrackService.cs
+++ b/OneDrive-Cloud-Player/Models/Interfaces/IMediaTrackService.cs
@@ -1,0 +1,37 @@
+﻿using LibVLCSharp.Shared;
+using LibVLCSharp.Shared.Structures;
+using System.Threading.Tasks;
+
+namespace OneDrive_Cloud_Player.Models.Interfaces
+{
+    public interface IMediaTrackService
+    {
+        /// <summary>
+        /// Needs to be called before using the service and before subscribing to other libvlcsharp events.<br />
+        /// Due to LibVLCSharp's inability for the MediaPlayer to be put into a service, we need to get a reference to the MediaPlayer ourselves instead.<br />
+        /// Initialize this service by parsing the MediaPlayer object reference for its media tracks.
+        /// </summary>
+        /// <param name="mediaPlayer"></param>
+        /// <returns></returns>
+        IMediaTrackService Initialize(ref MediaPlayer mediaPlayer);
+
+        /// <summary>
+        /// Get the preferred subtitle track. When no preferred subtitle track is found, a default will be returned.
+        /// <br />
+        /// <i>Note: This method should not be called on a LibVLC thread.
+        /// <see href="https://code.videolan.org/videolan/LibVLCSharp/-/blob/3.x/docs/best_practices.md#do-not-call-libvlc-from-a-libvlc-event-without-switching-thread-first">Here</see> is more info on why.</i>
+        /// </summary>
+        /// <returns><see cref="TrackDescription"/> Preferred subtitle track or default</returns>
+        /// <exception cref="ServiceNotInitializedException"></exception>
+        TrackDescription GetPreferredSubtitleTrack();
+
+        /// <summary>
+        /// Get the embedded subtitle tracks in the media file.
+        /// <br />
+        /// <i>Note: This method should not be called on a LibVLC thread.
+        /// <see href="https://code.videolan.org/videolan/LibVLCSharp/-/blob/3.x/docs/best_practices.md#do-not-call-libvlc-from-a-libvlc-event-without-switching-thread-first">Here</see> is more info on why.</i>
+        /// </summary>
+        /// <returns>Array containing <see cref="TrackDescription"/>'s or empty when no tracks are available</returns>
+        TrackDescription[] GetEmbeddedSubtitleTracks();
+    }
+}

--- a/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
+++ b/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
@@ -130,15 +130,18 @@
     <Compile Include="Models\GraphData\CachedDrive.cs" />
     <Compile Include="Models\GraphData\CachedDriveItem.cs" />
     <Compile Include="Models\GraphData\OneDriveCache.cs" />
+    <Compile Include="Models\Interfaces\IMediaTrackService.cs" />
     <Compile Include="Models\Interfaces\INavigable.cs" />
     <Compile Include="Models\MediaWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\Converters\MainPageExplorerConverter.cs" />
     <Compile Include="Services\Converters\MediaTimeConverter.cs" />
+    <Compile Include="Services\Converters\ValueConverterGroup.cs" />
     <Compile Include="Services\Helpers\CacheHelper.cs" />
     <Compile Include="Services\Helpers\GraphHelper.cs" />
     <Compile Include="Services\Helpers\GraphAuthHelper.cs" />
     <Compile Include="Services\NavigationService.cs" />
+    <Compile Include="Services\MediaTrackService.cs" />
     <Compile Include="Services\Utilities\JsonHandler.cs" />
     <Compile Include="ViewModels\LoginPageViewModel.cs" />
     <Compile Include="ViewModels\MainPageViewModel.cs" />
@@ -153,6 +156,9 @@
     </Compile>
     <Compile Include="Views\SettingsPage.xaml.cs">
       <DependentUpon>SettingsPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\SubtitleAudioTrackSelector.xaml.cs">
+      <DependentUpon>SubtitleAudioTrackSelector.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\VideoPlayerPage.xaml.cs">
       <DependentUpon>VideoPlayerPage.xaml</DependentUpon>
@@ -250,6 +256,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Views\SubtitleAudioTrackSelector.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\VideoPlayerPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -276,6 +286,12 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Mvvm">
       <Version>7.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
+      <Version>7.1.3</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.UI.Xaml">
+      <Version>2.8.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.1</Version>

--- a/OneDrive-Cloud-Player/Services/Converters/MediaTimeConverter.cs
+++ b/OneDrive-Cloud-Player/Services/Converters/MediaTimeConverter.cs
@@ -6,7 +6,7 @@ namespace OneDrive_Cloud_Player.Services.Converters
     class MediaTimeConverter : IValueConverter
     {
         object IValueConverter.Convert(object timeMs, Type targetType, object parameter, string language)
-        { 
+        {
             TimeSpan timeSpan = TimeSpan.FromMilliseconds(Convert.ToDouble(timeMs));
             return timeSpan.ToString(@"hh\:mm\:ss");
         }

--- a/OneDrive-Cloud-Player/Services/Converters/ValueConverterGroup.cs
+++ b/OneDrive-Cloud-Player/Services/Converters/ValueConverterGroup.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Windows.UI.Xaml.Data;
+
+namespace OneDrive_Cloud_Player.Services.Converters
+{
+    public class ValueConverterGroup : List<IValueConverter>, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            return this.Aggregate(value, (current, converter) => converter.Convert(current, targetType, parameter, language));
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/OneDrive-Cloud-Player/Services/MediaTrackService.cs
+++ b/OneDrive-Cloud-Player/Services/MediaTrackService.cs
@@ -1,0 +1,90 @@
+﻿using LibVLCSharp.Shared;
+using LibVLCSharp.Shared.Structures;
+using OneDrive_Cloud_Player.Models.Interfaces;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Windows.Storage;
+
+namespace OneDrive_Cloud_Player.Services
+{
+    /// <summary>
+    /// Manage the media tracks of the libvlcsharp media player instance.
+    /// </summary>
+    public class MediaTrackService : IMediaTrackService
+    {
+        private MediaPlayer _mediaPlayer;
+        private bool _isInitialized = false;
+        private readonly ApplicationDataContainer _userSettings;
+
+        public MediaTrackService()
+        {
+            _userSettings = ApplicationData.Current.LocalSettings;
+        }
+
+        /// <summary>
+        /// Due to LibVLCSharp's inability for the MediaPlayer to be put into a service, we need to get a reference to the MediaPlayer ourselves instead.
+        /// Initialize this service by parsing the MediaPlayer object reference for its media tracks.
+        /// </summary>
+        public IMediaTrackService Initialize(ref MediaPlayer mediaPlayer)
+        {
+            if (_isInitialized)
+            {
+                throw new InvalidOperationException("Service already initialized!");
+            }
+
+            Debug.WriteLine(String.Format("initializing {0}", GetType().Name));
+            _mediaPlayer = mediaPlayer;
+            _isInitialized = true;
+            return this;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        private void CheckInitializationState()
+        {
+            if (!_isInitialized)
+            {
+                throw new InvalidOperationException("Service not initialized!");
+            }
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <returns> <inheritdoc/></returns>
+        public TrackDescription GetPreferredSubtitleTrack()
+        {
+            CheckInitializationState();
+            TrackDescription[] subtitleTracks = _mediaPlayer.SpuDescription;
+
+            if (_mediaPlayer.SpuCount <= 0)
+            {
+                return default;
+            }
+
+            // Return default track subtitle (when possible, like in mkv) depending on the user setting.
+            if ((bool)_userSettings.Values["ShowDefaultSubtitles"])
+            {
+                return subtitleTracks.First(subtitleTrack => subtitleTrack.Id == _mediaPlayer.Spu);
+            }
+            else
+            {
+                // Return the "disabled" indicator track positioned at index 0.
+                return _mediaPlayer.SpuDescription.ElementAt(0);
+            }
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        /// <returns><inheritdoc/></returns>
+        public TrackDescription[] GetEmbeddedSubtitleTracks()
+        {
+            CheckInitializationState();
+            return _mediaPlayer.SpuDescription;
+        }
+    }
+}

--- a/OneDrive-Cloud-Player/Views/SubtitleAudioTrackSelector.xaml
+++ b/OneDrive-Cloud-Player/Views/SubtitleAudioTrackSelector.xaml
@@ -1,0 +1,49 @@
+﻿<UserControl
+    x:Class="OneDrive_Cloud_Player.Views.SubtitleAudioTrackSelector"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:libvlcSharp="using:LibVLCSharp.Shared.Structures"
+    xmlns:converters="using:OneDrive_Cloud_Player.Services.Converters"
+    xmlns:convertersToolkit="using:Microsoft.Toolkit.Uwp.UI.Converters">
+
+    <UserControl.Resources>
+        <convertersToolkit:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
+        <converters:ValueConverterGroup x:Key="InvertBoolToVisibilityConverter">
+            <convertersToolkit:BoolNegationConverter/>
+            <convertersToolkit:BoolToVisibilityConverter />
+        </converters:ValueConverterGroup>
+    </UserControl.Resources>
+
+    <StackPanel>
+        <StackPanel Orientation="Horizontal" Padding="5">
+            <TextBlock Text="Subtitles" Opacity="0.7" FontSize="13"/>
+        </StackPanel>
+        <TextBlock Text="No Tracks"
+                   FontStyle="Italic"
+                   Visibility="{x:Bind Path=IsSubtitlesAvailable, Converter={StaticResource InvertBoolToVisibilityConverter}, Mode=OneWay}">
+
+        </TextBlock>
+        <ListView Visibility="{x:Bind Path=IsSubtitlesAvailable, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
+                  ItemsSource="{x:Bind SubtitleTracks, Mode=OneWay}"
+                  SelectedItem="{Binding SelectedSubtitleTrack, Mode=TwoWay}"
+                  ItemClick="SubtitleTrackListView_ItemClick"
+                  Name="SubtitleTrackListView"
+                  IsItemClickEnabled="True">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="libvlcSharp:TrackDescription">
+                    <StackPanel>
+                        <TextBlock Text="{x:Bind Name}"></TextBlock>
+                    </StackPanel>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+        <StackPanel Orientation="Horizontal" Padding="5">
+            <TextBlock Text="Audio" Opacity="0.7" FontSize="13"/>
+        </StackPanel>
+        <TextBlock Text="No Tracks"
+                   FontStyle="Italic"
+                   Visibility="Visible">
+
+        </TextBlock>
+    </StackPanel>
+</UserControl>

--- a/OneDrive-Cloud-Player/Views/SubtitleAudioTrackSelector.xaml.cs
+++ b/OneDrive-Cloud-Player/Views/SubtitleAudioTrackSelector.xaml.cs
@@ -1,0 +1,128 @@
+﻿using LibVLCSharp.Shared.Structures;
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Diagnostics;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace OneDrive_Cloud_Player.Views
+{
+    public sealed partial class SubtitleAudioTrackSelector : UserControl, INotifyPropertyChanged
+    {
+        public event EventHandler ItemClicked;
+
+        private bool _isSubtitlesAvailable = false;
+        public bool IsSubtitlesAvailable
+        {
+            get { return _isSubtitlesAvailable; }
+            set
+            {
+                _isSubtitlesAvailable = value;
+                OnPropertyChanged(nameof(IsSubtitlesAvailable));
+            }
+        }
+
+        public ObservableCollection<TrackDescription> SubtitleTracks
+        {
+            get { return (ObservableCollection<TrackDescription>)GetValue(SubtitleTracksProperty); }
+            set { SetValue(SubtitleTracksProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for SubtitleTracks. This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty SubtitleTracksProperty =
+            DependencyProperty.Register("SubtitleTracks", typeof(ObservableCollection<TrackDescription>), typeof(SubtitleAudioTrackSelector), new PropertyMetadata(null, SubtitleTracksPropertyChangedCallback));
+
+        public TrackDescription SelectedSubtitleTrack
+        {
+            get { return (TrackDescription)GetValue(SelectedSubtitleTrackProperty); }
+            set { SetValue(SelectedSubtitleTrackProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for SelectedTrack. This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty SelectedSubtitleTrackProperty =
+            DependencyProperty.Register("SelectedSubtitleTrack", typeof(TrackDescription), typeof(SubtitleAudioTrackSelector), new PropertyMetadata(null));
+
+        public SubtitleAudioTrackSelector()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Callback for SubtitleTracksProperty property changes.
+        /// </summary>
+        /// <param name="dependencyObject"></param>
+        /// <param name="eventArgs"></param>
+        private static void SubtitleTracksPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
+        {
+            SubtitleAudioTrackSelector subtitleAudioTrackSelector = (SubtitleAudioTrackSelector)dependencyObject;
+            if (((ObservableCollection<TrackDescription>)eventArgs.NewValue).Count > 0)
+            {
+                subtitleAudioTrackSelector.IsSubtitlesAvailable = true;
+            }
+
+            if (eventArgs.NewValue is INotifyCollectionChanged newCollection)
+            {
+                // Subscribe to changes inside the new collection.
+                newCollection.CollectionChanged += subtitleAudioTrackSelector.SubtitleTracks_CollectionChanged;
+            }
+
+            if (eventArgs.OldValue is INotifyCollectionChanged oldCollection)
+            {
+                // Unsubscribe to changes inside the old collection.
+                oldCollection.CollectionChanged -= subtitleAudioTrackSelector.SubtitleTracks_CollectionChanged;
+            }
+        }
+
+        /// <summary>
+        /// Hnadling changes that occur inside the subtitle tracks collection (i.e. added or removed).
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void SubtitleTracks_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            // Check for Default value.
+            if (e.NewItems == null)
+            {
+                IsSubtitlesAvailable = false;
+                return;
+            }
+
+            // Check if there are subtitles.
+            if (e.NewItems.Count <= 0)
+            {
+                IsSubtitlesAvailable = false;
+                return;
+            }
+
+            IsSubtitlesAvailable = true;
+        }
+
+        /// <summary>
+        /// Invoke the custom <see cref="ItemClicked"/> event when a subtitle item in the listview is clicked.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void SubtitleTrackListView_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            Debug.WriteLine("Subtitle item clicked from listview.");
+            ItemClicked?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// When called, notifies the UI that the property value has changed.
+        /// </summary>
+        /// <param name="prop">Name of the property which value has changed</param>
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChangedEventHandler handler = PropertyChanged;
+
+            if (handler != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+}

--- a/OneDrive-Cloud-Player/Views/VideoPlayerPage.xaml
+++ b/OneDrive-Cloud-Player/Views/VideoPlayerPage.xaml
@@ -453,6 +453,7 @@
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
 
                         <!--Stop Button-->
@@ -474,6 +475,19 @@
                         Command="{Binding ReloadCurrentMediaCommand}"
                         Background="Transparent">
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE777;"/>
+                        </Button>
+                        <Button Grid.Column="3" Width="50" Height="50" Background="Transparent">
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xED1F;"/>
+                            <!--Flyout for changing subtitle and audio track-->
+                            <Button.Flyout>
+                                <Flyout x:Name="AudioSubtitleSelectorFlyout">
+                                    <!--Audio subtitle track selector-->
+                                    <local:SubtitleAudioTrackSelector SubtitleTracks="{Binding SubtitleTracks, Mode=OneWay}"
+                                                                      SelectedSubtitleTrack="{Binding SelectedSubtitleTrack, Mode=TwoWay}"
+                                                                      ItemClicked="SubtitleAudioTrackSelector_ItemClicked">
+                                    </local:SubtitleAudioTrackSelector>
+                                </Flyout>
+                            </Button.Flyout>
                         </Button>
                     </Grid>
                     <Grid Grid.Column="1">

--- a/OneDrive-Cloud-Player/Views/VideoPlayerPage.xaml.cs
+++ b/OneDrive-Cloud-Player/Views/VideoPlayerPage.xaml.cs
@@ -274,5 +274,15 @@ namespace OneDrive_Cloud_Player.Views
 
             base.OnNavigatingFrom(e);
         }
+
+        /// <summary>
+        /// Hide the subtitle audio track selector flyout when an item inside of it is clicked.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void SubtitleAudioTrackSelector_ItemClicked(object sender, EventArgs e)
+        {
+            AudioSubtitleSelectorFlyout.Hide();
+        }
     }
 }


### PR DESCRIPTION
Implemented the ability to select a subtitle track on the video player page.

Added a SubtitleAudioTrackSelector UserControl. This UserControl hosts the subtitle tracks and will also host the audio tracks from which a user can select a track.

Introduced a MediaTrackService which can be injected to provide some methods. Methods it provide are at this moment the retrieval of subtitle tracks and the preferred subtitle track. Due to LibVLC not being able to be injected by a dependency injector due to several reasons, this service needs to be initialized by calling the initialize method and providing it with a reference to a (initialized!) MediaPlayer instance. This service can be expanded to perform more general MediaPlayer tasks as well in the future if need be.

Added a ValueConverterGroup enabling the chaining of value converters.

Added a custom exception which gets thrown when one of the the MediaTrackService methods get called without the service being initialized.

Added MediaTrackService to the dependency Injector container in App.xaml.cs.

resolves #86 